### PR TITLE
Feat : 중복되는 쿠폰명 예외처리, 상품아이디 리스트로 고정, 비율 쿠폰 조회, Feign Client 요청 API 리턴값 수정 (Order 사용)

### DIFF
--- a/src/main/java/shop/kokodo/promotionservice/controller/FixCouponController.java
+++ b/src/main/java/shop/kokodo/promotionservice/controller/FixCouponController.java
@@ -8,9 +8,11 @@ import shop.kokodo.promotionservice.dto.FixCouponDto;
 import shop.kokodo.promotionservice.dto.ProductDto;
 import shop.kokodo.promotionservice.dto.response.Response;
 import shop.kokodo.promotionservice.entity.FixCoupon;
+import shop.kokodo.promotionservice.entity.RateCoupon;
 import shop.kokodo.promotionservice.service.FixCouponService;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,6 +40,11 @@ public class FixCouponController {
     public Response findProductByName(@PathVariable String name){
         List<ProductDto> products = fixCouponService.findProductByName(name);
         return Response.success(products);
+    }
+
+    @GetMapping("/coupon/list")
+    public List<Long> findFixCouponByCouponIdList(@RequestParam List<Long> couponIdList){
+        return fixCouponService.findByCouponIdList(couponIdList);
     }
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/controller/RateCouponController.java
+++ b/src/main/java/shop/kokodo/promotionservice/controller/RateCouponController.java
@@ -10,6 +10,7 @@ import shop.kokodo.promotionservice.service.RateCouponService;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/rateCoupon")
@@ -44,6 +45,14 @@ public class RateCouponController {
         List<ProductDto> products = rateCouponService.findProductByRateCouponName(name);
 
         return Response.success(products);
+    }
+
+    /*
+        productId - List<RateCoupon
+     */
+    @GetMapping("/coupon/list")
+    public Map<Long,List<RateCoupon>> findRateCouponByCouponIdList(@RequestParam List<Long> couponIdList){
+        return rateCouponService.findByCouponIdList(couponIdList);
     }
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/controller/UserCouponController.java
+++ b/src/main/java/shop/kokodo/promotionservice/controller/UserCouponController.java
@@ -19,6 +19,7 @@ import shop.kokodo.promotionservice.service.UserCouponService;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/userCoupon")
@@ -89,17 +90,24 @@ public class UserCouponController {
         }
         return Response.success();
     }
-
+    // productId - List<RateCoupon> 리턴
     @GetMapping("/rateCoupon/list")
     public Response rateCouponList(@RequestParam List<Long> productIdList, @RequestHeader long memberId){
-        List<ProductIdAndRateCouponDto> list = userCouponService.findRateCouponByMemberIdAndProductId(productIdList,memberId);
+        return Response.success(userCouponService.findRateCouponByMemberIdAndProductId(productIdList,memberId));
 
-        return Response.success(list);
     }
 
+    /**
+     * productList에서 무료배송쿠폰이 있는 sellerId만 전송
+     * @param productIdList
+     * @param memberId
+     * @return
+     */
     @GetMapping("/fixCoupon/list")
     public Response fixCouponList(@RequestParam List<Long> productIdList, @RequestHeader long memberId){
         return Response.success(userCouponService.findFixCouponByMemberIdAndProductId(productIdList,memberId));
     }
+
+
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/repository/FixCouponRepository.java
+++ b/src/main/java/shop/kokodo/promotionservice/repository/FixCouponRepository.java
@@ -35,5 +35,8 @@ public interface FixCouponRepository extends JpaRepository<FixCoupon,Long> {
 
     Optional<FixCoupon> findByName(String name);
 
+    @Query(value="select f from FixCoupon f where f.id in :couponIdList ")
+    List<FixCoupon> findByCouponIdList(List<Long> couponIdList);
+
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/repository/FixCouponRepository.java
+++ b/src/main/java/shop/kokodo/promotionservice/repository/FixCouponRepository.java
@@ -7,6 +7,7 @@ import shop.kokodo.promotionservice.entity.FixCoupon;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FixCouponRepository extends JpaRepository<FixCoupon,Long> {
@@ -32,6 +33,7 @@ public interface FixCouponRepository extends JpaRepository<FixCoupon,Long> {
             "and f.id in (select u.fixCoupon.id from UserCoupon u where u.userId=1 and u.usageStatus=0 and u.fixCoupon is not null and u.userId=:memberId ) ")
     List<FixCoupon> findValidFixCoupon(Long memberId, List<Long> productIdList, LocalDateTime now);
 
+    Optional<FixCoupon> findByName(String name);
 
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/repository/RateCouponRepository.java
+++ b/src/main/java/shop/kokodo/promotionservice/repository/RateCouponRepository.java
@@ -36,4 +36,8 @@ public interface RateCouponRepository extends JpaRepository<RateCoupon, Long> {
 
     Optional<RateCoupon> findByName(String name);
 
+    @Query(value="select r from RateCoupon r " +
+            "where r.id in :rateCouponIdList ")
+    List<RateCoupon> findByIdList(List<Long> rateCouponIdList);
+
 }

--- a/src/main/java/shop/kokodo/promotionservice/repository/RateCouponRepository.java
+++ b/src/main/java/shop/kokodo/promotionservice/repository/RateCouponRepository.java
@@ -8,6 +8,7 @@ import shop.kokodo.promotionservice.entity.RateCoupon;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RateCouponRepository extends JpaRepository<RateCoupon, Long> {
@@ -32,5 +33,7 @@ public interface RateCouponRepository extends JpaRepository<RateCoupon, Long> {
     @Query(value = "select r.productId from RateCoupon r "+
                 "where r.name = :name ")
     public List<Long> findProductIdByName(String name);
+
+    Optional<RateCoupon> findByName(String name);
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/service/FixCouponService.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/FixCouponService.java
@@ -16,4 +16,6 @@ public interface FixCouponService {
 
     List<ProductDto> findProductByName(String name);
 
+    List<Long> findByCouponIdList(List<Long> couponIdList);
+
 }

--- a/src/main/java/shop/kokodo/promotionservice/service/FixCouponServiceImpl.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/FixCouponServiceImpl.java
@@ -21,6 +21,7 @@ public class FixCouponServiceImpl implements FixCouponService{
     private final ProductServiceClient productServiceClient;
     @Override
     public void save(FixCouponDto fixCouponDto) {
+        if(fixCouponRepository.findByName(fixCouponDto.getName()).isPresent()) throw new IllegalArgumentException("이미 존재하는 쿠폰 이름");
 
         FixCoupon fixCoupon;
         for (Long productId : fixCouponDto.getProductList()) {

--- a/src/main/java/shop/kokodo/promotionservice/service/FixCouponServiceImpl.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/FixCouponServiceImpl.java
@@ -11,6 +11,7 @@ import shop.kokodo.promotionservice.repository.FixCouponRepository;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -47,6 +48,19 @@ public class FixCouponServiceImpl implements FixCouponService{
         List<Long> productIdList = fixCouponRepository.findProductIdByName(name);
 
         return productServiceClient.findProductByName(productIdList);
+    }
+
+    @Override
+    public List<Long> findByCouponIdList(List<Long> couponIdList) {
+        List<FixCoupon> fixCouponList = fixCouponRepository.findByCouponIdList(couponIdList);
+
+        List<Long> sellerIdList = new ArrayList<>();
+
+        for (FixCoupon fixCoupon : fixCouponList) {
+            long sellerId = fixCoupon.getSellerId();
+            if(!sellerIdList.contains(sellerId)) sellerIdList.add(sellerId);
+        }
+        return sellerIdList;
     }
 
 

--- a/src/main/java/shop/kokodo/promotionservice/service/RateCouponService.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/RateCouponService.java
@@ -7,6 +7,7 @@ import shop.kokodo.promotionservice.entity.RateCoupon;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public interface RateCouponService {
 
@@ -18,5 +19,7 @@ public interface RateCouponService {
     public List<RateCoupon> findByProductId(long productId);
 
     public List<ProductDto> findProductByRateCouponName(String name);
+
+    Map<Long, List<RateCoupon>> findByCouponIdList(List<Long> couponIdList);
 
 }

--- a/src/main/java/shop/kokodo/promotionservice/service/RateCouponServiceImpl.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/RateCouponServiceImpl.java
@@ -28,7 +28,7 @@ public class RateCouponServiceImpl implements RateCouponService{
 
     @Override
     public void save(RateCouponDto rateCouponDto) {
-
+        if(rateCouponRepository.findByName(rateCouponDto.getName()).isPresent()) throw new IllegalArgumentException("이미 존재하는 쿠폰명");
         for (Long productId : rateCouponDto.getProductList()) {
             RateCoupon rateCoupon=convertToRateCoupon(rateCouponDto,productId);
             rateCouponRepository.save(rateCoupon);

--- a/src/main/java/shop/kokodo/promotionservice/service/RateCouponServiceImpl.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/RateCouponServiceImpl.java
@@ -12,7 +12,10 @@ import shop.kokodo.promotionservice.repository.RateCouponRepository;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -57,6 +60,30 @@ public class RateCouponServiceImpl implements RateCouponService{
 
         return productServiceClient.findProductByName(productIdList);
     }
+
+    @Override
+    public Map<Long, List<RateCoupon>> findByCouponIdList(List<Long> couponIdList) {
+        List<RateCoupon> rateCouponList = rateCouponRepository.findByIdList(couponIdList);
+        // productId - rateCoupon 리스트
+        Map<Long, List<RateCoupon>> productIdAndRateCouponListMap = new HashMap<>();
+
+        for (RateCoupon rateCoupon : rateCouponList) {
+            long productId =rateCoupon.getProductId();
+            if(productIdAndRateCouponListMap.containsKey(productId)){
+                List<RateCoupon> tmp = productIdAndRateCouponListMap.get(productId);
+                tmp.add(rateCoupon);
+                productIdAndRateCouponListMap.put(productId,tmp);
+            }
+            else{
+                List<RateCoupon> tmp = new ArrayList<>();
+                tmp.add(rateCoupon);
+                productIdAndRateCouponListMap.put(productId,tmp);
+            }
+        }
+
+        return productIdAndRateCouponListMap;
+    }
+
 
     private RateCoupon convertToRateCoupon(RateCouponDto rateCouponDto, long productId){
         return RateCoupon.builder()

--- a/src/main/java/shop/kokodo/promotionservice/service/UserCouponService.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/UserCouponService.java
@@ -9,6 +9,7 @@ import shop.kokodo.promotionservice.entity.RateCoupon;
 import shop.kokodo.promotionservice.entity.UserCoupon;
 
 import java.util.List;
+import java.util.Map;
 
 public interface UserCouponService {
 
@@ -19,9 +20,9 @@ public interface UserCouponService {
 
     public UserCoupon updateUsageStatus(UpdateUserCouponDto updateUserCouponDto, long userId);
 
-    public List<ProductIdAndRateCouponDto> findRateCouponByMemberIdAndProductId(List<Long> productIdList, long memberId);
+    public Map<Long, List<RateCoupon>> findRateCouponByMemberIdAndProductId(List<Long> productIdList, long memberId);
 //    public List<FixCoupon> findFixCouponByMemberIdAndProductId(long productId, long memberId);
 
-    public List<ProductIdAndFixCouponDto> findFixCouponByMemberIdAndProductId(List<Long> productIds, long memberId);
+    public List<Long> findFixCouponByMemberIdAndProductId(List<Long> productIds, long memberId);
 
     }

--- a/src/main/java/shop/kokodo/promotionservice/service/UserCouponServiceImpl.java
+++ b/src/main/java/shop/kokodo/promotionservice/service/UserCouponServiceImpl.java
@@ -105,17 +105,16 @@ public class UserCouponServiceImpl implements UserCouponService{
     }
 
     @Override
-    public List<ProductIdAndRateCouponDto> findRateCouponByMemberIdAndProductId(List<Long> productIdList, long memberId) {
+    public Map<Long, List<RateCoupon>> findRateCouponByMemberIdAndProductId(List<Long> productIdList, long memberId) {
 
         List<UserCoupon> list = userCouponRepository.findByInProductIdAndMemberId(productIdList,memberId, LocalDateTime.now());
 
-        List<ProductIdAndRateCouponDto> rateCoupons = new ArrayList<>();
-        Map<Long, ArrayList<RateCoupon>> productIdAndRateCouponListMap = new HashMap<>();
+        Map<Long, List<RateCoupon>> productIdAndRateCouponListMap = new HashMap<>();
 
         for (UserCoupon userCoupon : list) {
             long productId = userCoupon.getRateCoupon().getProductId();
             if(productIdAndRateCouponListMap.containsKey(productId)) {
-                ArrayList<RateCoupon> rateCouponList = productIdAndRateCouponListMap.get(productId);
+                List<RateCoupon> rateCouponList = productIdAndRateCouponListMap.get(productId);
                 rateCouponList.add(userCoupon.getRateCoupon());
                 productIdAndRateCouponListMap.put(productId,rateCouponList);
             }
@@ -127,42 +126,19 @@ public class UserCouponServiceImpl implements UserCouponService{
             }
         }
 
-        for (Long productId : productIdAndRateCouponListMap.keySet()) {
-            rateCoupons.add(createProductIdAndRateCouponDto(productId,productIdAndRateCouponListMap.get(productId)));
-        }
-
-        return rateCoupons;
+        return productIdAndRateCouponListMap;
     }
 
     @Override
-    public List<ProductIdAndFixCouponDto> findFixCouponByMemberIdAndProductId(List<Long> productIds, long memberId) {
+    public List<Long> findFixCouponByMemberIdAndProductId(List<Long> productIds, long memberId) {
        List<FixCoupon> fixCouponList = fixCouponRepository.findValidFixCoupon( memberId, productIds, LocalDateTime.now());
 
-        List<ProductIdAndFixCouponDto> productIdAndFixCouponDtoList = new ArrayList<>();
-        Map<Long,List<FixCoupon>> productIdAndFixCouponMap =new HashMap<>();
-
+        List<Long> list = new ArrayList<>();
         for (FixCoupon fixCoupon : fixCouponList) {
-            long productId = fixCoupon.getProductId();
-            if(productIdAndFixCouponMap.containsKey(fixCoupon.getProductId())){
-                List<FixCoupon> tmpFixCouponList = productIdAndFixCouponMap.get(productId);
-                tmpFixCouponList.add(fixCoupon);
-                productIdAndFixCouponMap.put(productId,tmpFixCouponList);
-            }
-            else{
-                List<FixCoupon> tmpFixCouponList = new ArrayList<>();
-                tmpFixCouponList.add(fixCoupon);
-                productIdAndFixCouponMap.put(productId,tmpFixCouponList);
-            }
+            if(!list.contains(fixCoupon.getSellerId())) list.add(fixCoupon.getSellerId());
         }
 
-        for (Long productId : productIdAndFixCouponMap.keySet()) {
-            productIdAndFixCouponDtoList.add(ProductIdAndFixCouponDto
-                    .builder()
-                            .productId(productId)
-                            .fixCouponList(productIdAndFixCouponMap.get(productId))
-                    .build());
-        }
-        return productIdAndFixCouponDtoList;
+        return list;
     }
 
     private UserCoupon convertToUserFixCoupon(UserCouponDto userCouponDto, FixCoupon fixCoupon){

--- a/src/test/java/shop/kokodo/promotionservice/service/UserCouponServiceTest.java
+++ b/src/test/java/shop/kokodo/promotionservice/service/UserCouponServiceTest.java
@@ -19,6 +19,7 @@ import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @SpringBootTest
 @Transactional
@@ -113,13 +114,14 @@ public class UserCouponServiceTest {
         userCouponRepository.save(userCoupon5);
         userCouponRepository.save(userCoupon6);
 
-        List<ProductIdAndRateCouponDto> productIdAndRateCouponDtos
+
+        Map<Long, List<RateCoupon>> productIdAndRateCouponDtos
             =userCouponService.findRateCouponByMemberIdAndProductId(productIdList,userId);
 
         System.out.println(productIdAndRateCouponDtos.size());
 
-        for (ProductIdAndRateCouponDto productIdAndRateCouponDto : productIdAndRateCouponDtos) {
-            System.out.println(productIdAndRateCouponDto.getProductId()+" "+productIdAndRateCouponDto.getRateCouponList());
-        }
+//        for (ProductIdAndRateCouponDto productIdAndRateCouponDto : productIdAndRateCouponDtos) {
+//            System.out.println(productIdAndRateCouponDto.getProductId()+" "+productIdAndRateCouponDto.getRateCouponList());
+//        }
     }
 }


### PR DESCRIPTION
- 쿠폰명 중복되는 경우 예외처리
- 상품아이디 리스트에 해당하는 비율 쿠폰 조회
       - productId - RateCoupon 쌍으로 Map 리턴
- 상품아이디 리스트에 해당하는 고정 쿠폰 조회
       - 해당하는 sellerId만 리턴
- Feign Client 요청에 사용하는 API 리턴값 수정